### PR TITLE
fix: resolve desktop and mobile wallet connection issues

### DIFF
--- a/src/components/ConnectButtonWrapper.tsx
+++ b/src/components/ConnectButtonWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { useAccount, useConnect } from 'wagmi';
 import { Zap } from 'lucide-react';
-import { getMobileConnectionStrategy } from '../utils/mobileDetection';
+import { isMobile, getMobileConnectionStrategy } from '../utils/mobileDetection';
 
 interface ConnectButtonWrapperProps {
   variant?: 'default' | 'compact' | 'minimal' | 'primary' | 'secondary';
@@ -20,23 +20,30 @@ const ConnectButtonWrapper: React.FC<ConnectButtonWrapperProps> = ({
 }) => {
   const { address, isConnected } = useAccount();
   const { connectors, connect } = useConnect();
+  const isOnMobile = isMobile();
 
-  // Handle mobile-specific connection
-  const handleMobileConnect = () => {
-    const strategy = getMobileConnectionStrategy();
-    
-    if (strategy === 'injected') {
-      const injectedConnector = connectors.find(c => c.id === 'injected');
-      if (injectedConnector) {
-        connect({ connector: injectedConnector });
-        return;
+  // Handle mobile-specific connection with proper error handling
+  const handleMobileConnect = async () => {
+    try {
+      const strategy = getMobileConnectionStrategy();
+      
+      if (strategy === 'injected') {
+        const injectedConnector = connectors.find(c => c.type === 'injected');
+        if (injectedConnector) {
+          await connect({ connector: injectedConnector });
+          return true;
+        }
+      } else if (strategy === 'walletconnect') {
+        const wcConnector = connectors.find(c => c.type === 'walletConnect');
+        if (wcConnector) {
+          await connect({ connector: wcConnector });
+          return true;
+        }
       }
-    } else if (strategy === 'walletconnect') {
-      const wcConnector = connectors.find(c => c.id === 'walletConnect');
-      if (wcConnector) {
-        connect({ connector: wcConnector });
-        return;
-      }
+      return false;
+    } catch (error) {
+      console.error('Mobile connection failed:', error);
+      return false;
     }
   };
 
@@ -51,25 +58,33 @@ const ConnectButtonWrapper: React.FC<ConnectButtonWrapperProps> = ({
       );
     }
 
+    // Use mobile-specific logic only on mobile devices
+    if (isOnMobile) {
+      return (
+        <ConnectButton.Custom>
+          {({ openConnectModal }) => (
+            <button
+              onClick={async () => {
+                const success = await handleMobileConnect();
+                if (!success) {
+                  openConnectModal();
+                }
+              }}
+              className="bg-green-600 text-white px-8 py-4 rounded-xl hover:bg-green-700 transition-all transform hover:scale-105 font-semibold text-lg shadow-lg hover:shadow-xl flex items-center justify-center"
+            >
+              <Zap className="mr-2 h-5 w-5" />
+              Connect Wallet
+            </button>
+          )}
+        </ConnectButton.Custom>
+      );
+    }
+
+    // Desktop: use standard RainbowKit button
     return (
-      <ConnectButton.Custom>
-        {({ openConnectModal }) => (
-          <button
-            onClick={() => {
-              const strategy = getMobileConnectionStrategy();
-              if (strategy !== 'auto') {
-                handleMobileConnect();
-              } else {
-                openConnectModal();
-              }
-            }}
-            className="bg-green-600 text-white px-8 py-4 rounded-xl hover:bg-green-700 transition-all transform hover:scale-105 font-semibold text-lg shadow-lg hover:shadow-xl flex items-center justify-center"
-          >
-            <Zap className="mr-2 h-5 w-5" />
-            Connect Wallet
-          </button>
-        )}
-      </ConnectButton.Custom>
+      <div className="space-y-3">
+        <ConnectButton />
+      </div>
     );
   }
 
@@ -84,25 +99,33 @@ const ConnectButtonWrapper: React.FC<ConnectButtonWrapperProps> = ({
       );
     }
 
+    // Use mobile-specific logic only on mobile devices
+    if (isOnMobile) {
+      return (
+        <ConnectButton.Custom>
+          {({ openConnectModal }) => (
+            <button
+              onClick={async () => {
+                const success = await handleMobileConnect();
+                if (!success) {
+                  openConnectModal();
+                }
+              }}
+              className="bg-white text-green-600 px-8 py-4 rounded-xl hover:bg-gray-50 transition-all transform hover:scale-105 font-semibold text-lg shadow-lg hover:shadow-xl flex items-center justify-center"
+            >
+              <Zap className="mr-2 h-5 w-5" />
+              Connect Wallet
+            </button>
+          )}
+        </ConnectButton.Custom>
+      );
+    }
+
+    // Desktop: use standard RainbowKit button
     return (
-      <ConnectButton.Custom>
-        {({ openConnectModal }) => (
-          <button
-            onClick={() => {
-              const strategy = getMobileConnectionStrategy();
-              if (strategy !== 'auto') {
-                handleMobileConnect();
-              } else {
-                openConnectModal();
-              }
-            }}
-            className="bg-white text-green-600 px-8 py-4 rounded-xl hover:bg-gray-50 transition-all transform hover:scale-105 font-semibold text-lg shadow-lg hover:shadow-xl flex items-center justify-center"
-          >
-            <Zap className="mr-2 h-5 w-5" />
-            Connect Wallet
-          </button>
-        )}
-      </ConnectButton.Custom>
+      <div className="space-y-3">
+        <ConnectButton />
+      </div>
     );
   }
 
@@ -111,25 +134,29 @@ const ConnectButtonWrapper: React.FC<ConnectButtonWrapperProps> = ({
     return <ConnectButton showBalance={showBalance} />;
   }
 
-  return (
-    <ConnectButton.Custom>
-      {({ openConnectModal }) => (
-        <button
-          onClick={() => {
-            const strategy = getMobileConnectionStrategy();
-            if (strategy !== 'auto') {
-              handleMobileConnect();
-            } else {
-              openConnectModal();
-            }
-          }}
-          className="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
-        >
-          Connect Wallet
-        </button>
-      )}
-    </ConnectButton.Custom>
-  );
+  // Use mobile-specific logic only on mobile devices
+  if (isOnMobile) {
+    return (
+      <ConnectButton.Custom>
+        {({ openConnectModal }) => (
+          <button
+            onClick={async () => {
+              const success = await handleMobileConnect();
+              if (!success) {
+                openConnectModal();
+              }
+            }}
+            className="bg-green-800 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-200"
+          >
+            Connect Wallet
+          </button>
+        )}
+      </ConnectButton.Custom>
+    );
+  }
+
+  // Desktop: use standard RainbowKit button
+  return <ConnectButton />;
 };
 
 export default ConnectButtonWrapper;

--- a/src/utils/mobileDetection.ts
+++ b/src/utils/mobileDetection.ts
@@ -49,13 +49,16 @@ export const shouldUseWalletConnect = (): boolean => {
 };
 
 export const getMobileConnectionStrategy = () => {
-  if (isMetaMaskMobile() || isCoinbaseMobile() || isTrustWallet()) {
-    return 'injected'; // Use injected connector
+  // Only return mobile strategies if actually on mobile
+  if (!isMobile()) {
+    return 'auto';
   }
   
-  if (isMobile()) {
-    return 'walletconnect'; // Use WalletConnect for mobile browsers
+  // If in a wallet browser, use injected
+  if (isMetaMaskMobile() || isCoinbaseMobile() || isTrustWallet() || hasInjectedWallet()) {
+    return 'injected';
   }
   
-  return 'auto'; // Let RainbowKit decide
+  // Regular mobile browser without wallet, use WalletConnect
+  return 'walletconnect';
 };


### PR DESCRIPTION
- Use standard ConnectButton for desktop browsers (preserves RainbowKit flow)
- Apply mobile-specific logic only when isMobile() returns true
- Fix connector detection using connector.type instead of connector.id
- Add async error handling with fallback to RainbowKit modal
- Improve mobile detection strategy to only trigger on actual mobile devices

Fixes both desktop regression and mobile connection failures